### PR TITLE
Feature DB ports forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,17 @@
+MUMUKI_PORTS = (3000..3010).to_a - [3001] # Excluding classroom, see mumuki/mumuki-classroom#125
+
 Vagrant.configure(2) do |config|
   config.vm.box = 'ubuntu/trusty64'
 
   config.vm.box_check_update = false
   # (`vagrant box outdated` to update)
 
-  (3000..3010).each do |it|
+  MUMUKI_PORTS.each do |it|
     config.vm.network 'forwarded_port', guest: it, host: it
   end
 
   config.vm.provider 'virtualbox' do |vb|
-    vb.memory = '2048'
+    vb.memory = 2048
   end
 
   ssh_private_key_path = File.join Dir.home, '.ssh', 'id_rsa'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,5 @@
 MUMUKI_PORTS = (3000..3010).to_a - [3001] # Excluding classroom, see mumuki/mumuki-classroom#125
+DB_PORTS = [5432, 27017]
 
 Vagrant.configure(2) do |config|
   config.vm.box = 'ubuntu/trusty64'
@@ -6,7 +7,7 @@ Vagrant.configure(2) do |config|
   config.vm.box_check_update = false
   # (`vagrant box outdated` to update)
 
-  MUMUKI_PORTS.each do |it|
+  (MUMUKI_PORTS + DB_PORTS).each do |it|
     config.vm.network 'forwarded_port', guest: it, host: it
   end
 


### PR DESCRIPTION
PG forwarding won't work out of the box, https://github.com/mumuki/escualo.rb/issues/12 has to be adressed first. Manual configuration can be easily done, though.

Obviously, this assumes the host isn't running MongoDB nor PG, or at least not at the default ports. I know this is a strong assumption, but works for the current user(s) (only me, I guess :stuck_out_tongue:). 